### PR TITLE
Copy labels from source namespaces

### DIFF
--- a/pkg/controller/directimagemigration/namespace.go
+++ b/pkg/controller/directimagemigration/namespace.go
@@ -63,6 +63,7 @@ func (t *Task) ensureDestinationNamespaces() error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        destNsName,
 				Annotations: srcNS.Annotations,
+				Labels:      srcNS.Labels,
 			},
 		}
 		existingNamespace := &corev1.Namespace{}

--- a/pkg/controller/directvolumemigration/namespace.go
+++ b/pkg/controller/directvolumemigration/namespace.go
@@ -42,6 +42,7 @@ func (t *Task) ensureDestinationNamespaces() error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        destNsName,
 				Annotations: srcNS.Annotations,
+				Labels:      srcNS.Labels,
 			},
 		}
 		existingNamespace := &corev1.Namespace{}


### PR DESCRIPTION
This is needed to let users add labels to override PSA in case workload is running as root  on the source.