### PR TITLE
oc sa get-token is deprecated

### DIFF
--- a/hack/controller-sa-login.sh
+++ b/hack/controller-sa-login.sh
@@ -33,4 +33,4 @@ fi
 
 # Login to migration controller SA without making changes to original KUBECONFIG
 KUBECONFIG=$MIG_KUBECONFIG \
-oc login --token $(oc sa get-token migration-controller -n openshift-migration) > /dev/null
+oc login --token $(oc create token migration-controller --duration=24h -n openshift-migration) > /dev/null


### PR DESCRIPTION
oc sa get-token is deprecated and no longer works on openshift 4.14 and newer, replace with current oc create token command