### PR TITLE
Check if VM CRD is available when cutting over to the new storage

### DIFF
--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -15,6 +15,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -845,6 +846,9 @@ func (t *Task) quiesceVirtualMachines(client k8sclient.Client, restClient rest.I
 			&list,
 			options)
 		if err != nil {
+			if meta.IsNoMatchError(err) {
+				continue
+			}
 			return liberr.Wrap(err)
 		}
 		for _, vm := range list.Items {
@@ -894,6 +898,9 @@ func (t *Task) unQuiesceVirtualMachines(client k8sclient.Client, restClient rest
 			&list,
 			options)
 		if err != nil {
+			if meta.IsNoMatchError(err) {
+				continue
+			}
 			return liberr.Wrap(err)
 		}
 		for _, vm := range list.Items {

--- a/pkg/controller/migmigration/storage.go
+++ b/pkg/controller/migmigration/storage.go
@@ -17,6 +17,7 @@ import (
 	batchv1beta "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -640,6 +641,9 @@ func (t *Task) swapVirtualMachinePVCRefs(client k8sclient.Client, restConfig *re
 		list := &virtv1.VirtualMachineList{}
 		options := k8sclient.InNamespace(ns)
 		if err := client.List(context.TODO(), list, options); err != nil {
+			if k8smeta.IsNoMatchError(err) {
+				continue
+			}
 			t.Log.Error(err, "failed listing virtual machines", "namespace", ns)
 			continue
 		}


### PR DESCRIPTION
When cutting over to the new storage, we need to check if the VM CRD is installed in the cluster. If not we need to skip the quiesce of virtual machines.