### PR TITLE
Don't create DVM resource if no PVCs are present

### DIFF
--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -55,7 +55,7 @@ func (t *Task) buildDirectVolumeMigration() *migapi.DirectVolumeMigration {
 		Spec: migapi.DirectVolumeMigrationSpec{
 			SrcMigClusterRef:            t.PlanResources.SrcMigCluster.GetObjectReference(),
 			DestMigClusterRef:           t.PlanResources.DestMigCluster.GetObjectReference(),
-			PersistentVolumeClaims:      *pvcList,
+			PersistentVolumeClaims:      pvcList,
 			CreateDestinationNamespaces: true,
 		},
 	}
@@ -202,7 +202,7 @@ func (t *Task) getDVMPodProgress(dvm migapi.DirectVolumeMigration) []string {
 	return progress
 }
 
-func (t *Task) getDirectVolumeClaimList() *[]migapi.PVCToMigrate {
+func (t *Task) getDirectVolumeClaimList() []migapi.PVCToMigrate {
 	nsMapping := t.PlanResources.MigPlan.GetNamespaceMapping()
 	var pvcList []migapi.PVCToMigrate
 	for _, pv := range t.PlanResources.MigPlan.Spec.PersistentVolumes.List {
@@ -227,7 +227,7 @@ func (t *Task) getDirectVolumeClaimList() *[]migapi.PVCToMigrate {
 			Verify:             pv.Selection.Verify,
 		})
 	}
-	return &pvcList
+	return pvcList
 }
 
 func (t *Task) deleteDirectVolumeMigrationResources() error {

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -722,11 +722,13 @@ func (t *Task) Run(ctx context.Context) error {
 			return liberr.Wrap(err)
 		}
 	case CreateDirectVolumeMigration:
-		err := t.createDirectVolumeMigration()
-		if err != nil {
-			return liberr.Wrap(err)
+		if t.hasDirectVolumes() {
+			err := t.createDirectVolumeMigration()
+			if err != nil {
+				return liberr.Wrap(err)
+			}
 		}
-		if err = t.next(); err != nil {
+		if err := t.next(); err != nil {
 			return liberr.Wrap(err)
 		}
 	case WaitForDirectVolumeMigrationToComplete:
@@ -1677,11 +1679,7 @@ func (t *Task) hasDirectVolumes() bool {
 	if t.PlanResources.MigPlan.Spec.IndirectVolumeMigration {
 		return false
 	}
-	pvcList := t.getDirectVolumeClaimList()
-	if pvcList != nil {
-		return true
-	}
-	return false
+	return t.getDirectVolumeClaimList() != nil
 }
 
 // Get whether the associated plan has imagestreams to be migrated


### PR DESCRIPTION
in the migration plan and IndirectVolumeMigration is set to false.

Fixed `hasDirectVolumes` to properly return false when the list is empty. It was returning a pointer to the list before, and the list object was never nil and thus would never return false. Since slices are pointers already there was no need for a pointer to the slice.