### PR TITLE
Don't error on namespace mismatch when deleting stale VM migrations

### DIFF
--- a/pkg/controller/directvolumemigration/vm_test.go
+++ b/pkg/controller/directvolumemigration/vm_test.go
@@ -79,7 +79,7 @@ func TestTask_startLiveMigrations(t *testing.T) {
 				},
 			},
 			wantErr:         true,
-			expectedReasons: []string{"source and target namespaces must match: test-namespace:test-namespace2"},
+			expectedReasons: []string{"source and target namespaces must match"},
 		},
 		{
 			name: "running VM, no volumes",
@@ -1425,8 +1425,7 @@ func TestTaskDeleteStaleVirtualMachineInstanceMigrations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: true,
-			expectedMsg:   "source and target namespaces must match",
+			expectedError: false,
 		},
 		{
 			name:   "PVCs in same namespace, and persistent volume claims in DVM, but no VMs or VMIMs, should not return error",


### PR DESCRIPTION
If there is a mismatch between the namespaces then we don't have to clean up migrations since they are not allowed in that scenario.