### PR TITLE
Properly pass namespace based on source or destination

### DIFF
--- a/pkg/controller/migmigration/quiesce_test.go
+++ b/pkg/controller/migmigration/quiesce_test.go
@@ -108,7 +108,7 @@ func TestQuiesceVirtualMachine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.task.quiesceVirtualMachines(tt.client, tt.restClient); err != nil && !tt.wantErr {
+			if err := tt.task.quiesceVirtualMachines(tt.client, tt.restClient, tt.task.sourceNamespaces()); err != nil && !tt.wantErr {
 				t.Errorf("quiesceVirtualMachines() error = %v, wantErr %v", err, tt.wantErr)
 			} else if err == nil && tt.wantErr {
 				t.Errorf("quiesceVirtualMachines() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
The quiesce function assumed it was quiescing the
source namespace, but it is now possible to also
quiesce the destination namespace. This change passes the source or destination namespace to the quiesce function.

Also properly identify the source or destination cluster in the error message if a pod is not quiesced.