### PR TITLE
Skip volume migration rollback for non storage conversion

### DIFF
--- a/pkg/controller/directvolumemigration/directvolumemigration_controller.go
+++ b/pkg/controller/directvolumemigration/directvolumemigration_controller.go
@@ -328,6 +328,9 @@ func (r *ReconcileDirectVolumeMigration) cleanupTargetResourcesInNamespaces(dire
 	if err != nil {
 		return false, err
 	}
+	if destinationCluster == nil {
+		return false, nil
+	}
 
 	// Cleanup source resources
 	client, err := destinationCluster.GetClient(r)

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1395,6 +1395,7 @@ func (t *Task) hasAllProgressReportingCompleted() (bool, error) {
 		if err := t.populateVMMappings(ns); err != nil {
 			return false, err
 		}
+		t.Owner.Status.SkippedVolumes = []string{}
 		for _, vol := range vols {
 			matchString := fmt.Sprintf("%s/%s", ns, vol.Name)
 			if t.PlanResources.MigPlan.LiveMigrationChecked() &&
@@ -1420,7 +1421,6 @@ func (t *Task) hasAllProgressReportingCompleted() (bool, error) {
 			}
 		}
 	}
-
 	return t.Owner.AllReportingCompleted(), nil
 }
 


### PR DESCRIPTION
Only do a rollback if we are doing a direct storage conversion. Any other type of migration don't sync the data back to the source.

Fixed two other issues:
- NPE when a source cluster is not found
- On a live migration rollback, the skipped volumes where appended endlessly instead of resetting the
skipped list everything reconcile.