### PR TITLE
Ensure label selector matches both filesystem and block labels

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -868,7 +868,10 @@ func (t *Task) areRsyncTransferPodsRunning() (arePodsRunning bool, nonRunningPod
 	pvcMap := t.getPVCNamespaceMap()
 	dvmLabels := t.buildDVMLabels()
 	dvmLabels["purpose"] = DirectVolumeMigrationRsync
+	delete(dvmLabels, "app")
 	selector := labels.SelectorFromSet(dvmLabels)
+	appRequirement, _ := labels.NewRequirement("app", selection.In, []string{DirectVolumeMigrationRsyncTransfer, DirectVolumeMigrationRsyncTransferBlock})
+	selector.Add(*appRequirement)
 
 	for bothNs, _ := range pvcMap {
 		ns := getDestNs(bothNs)
@@ -1180,7 +1183,7 @@ func (t *Task) getRsyncPassword() (string, error) {
 		Namespace: migapi.OpenshiftMigrationNamespace,
 	}
 	t.Log.Info("Getting Rsync Password from Secret on host MigCluster",
-		"secret", path.Join(rsyncSecret.Namespace, rsyncSecret.Name))
+		"secret", path.Join(key.Namespace, key.Name))
 	err := t.Client.Get(context.TODO(), key, &rsyncSecret)
 	if k8serror.IsNotFound(err) {
 		t.Log.Info("Rsync Password Secret is not found on host MigCluster",


### PR DESCRIPTION
The block server pod had a slightly different label than the filesystem server pod, and this caused the code that waits for the server to be running to not match the pod. This then caused the clients to start while the server was not yet running. This leads to a race condition where the clients can attempt to
connect to the server before it is ready to accept the connections. This then leads to tls errors and the transfer failing.

Fixed issue with it not printing the correct name in the logs for the secret.