### PR TITLE
Label source PVCs with the migration plan UID

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -70,6 +70,7 @@ const (
 	DirectVolumeMigrationRsyncClient             = "rsync-client"
 	DirectVolumeMigrationStunnel                 = "stunnel"
 	MigratedByDirectVolumeMigration              = "migration.openshift.io/migrated-by-directvolumemigration" // (dvm UID)
+	MigrationSourceFor                           = "migration.openshift.io/source-for-directvolumemigration"  // (dvm UID)
 )
 
 // Itinerary names

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -10,6 +10,7 @@ import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
+	"github.com/konveyor/mig-controller/pkg/controller/directvolumemigration"
 	migpods "github.com/konveyor/mig-controller/pkg/pods"
 	migref "github.com/konveyor/mig-controller/pkg/reference"
 	"github.com/opentracing/opentracing-go"
@@ -384,6 +385,15 @@ func (r *ReconcileMigPlan) getClaims(client compat.Client, plan *migapi.MigPlan)
 		return false
 	}
 
+	migrationSourceOtherPlan := func(pvc core.PersistentVolumeClaim) bool {
+		if planuid, exists := pvc.Labels[directvolumemigration.MigrationSourceFor]; exists {
+			if planuid != string(plan.UID) {
+				return true
+			}
+		}
+		return false
+	}
+
 	isStorageConversionPlan := isStorageConversionPlan(plan)
 
 	for _, pod := range runningPods.Items {
@@ -397,7 +407,7 @@ func (r *ReconcileMigPlan) getClaims(client compat.Client, plan *migapi.MigPlan)
 			continue
 		}
 
-		if isStorageConversionPlan && alreadyMigrated(pvc) {
+		if isStorageConversionPlan && (alreadyMigrated(pvc) || migrationSourceOtherPlan(pvc)) {
 			continue
 		}
 


### PR DESCRIPTION
After successful migration, label the source PVCs
with the migration plan UID. This will allow us to easily identify which PVCs have been migrated and
which have not.

This can make it easier to remove the source PVCs
after migration is complete.