### PR TITLE
Fix quiesce not working for selected resources.

### DIFF
--- a/pkg/controller/migmigration/rollback.go
+++ b/pkg/controller/migmigration/rollback.go
@@ -272,18 +272,18 @@ func (t *Task) isLiveMigrationCompletedPod(pod *corev1.Pod, volumeNames []string
 	if len(pod.Spec.Volumes) == 0 {
 		return false
 	}
+	found := false
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
-			found := false
 			for _, volumeName := range volumeNames {
 				if volumeName == volume.PersistentVolumeClaim.ClaimName {
 					found = true
 				}
 			}
-			if !found {
-				return false
-			}
 		}
+	}
+	if !found {
+		return false
 	}
 	return pod.Status.Phase == corev1.PodSucceeded
 }

--- a/pkg/controller/migmigration/storage_test.go
+++ b/pkg/controller/migmigration/storage_test.go
@@ -61,7 +61,7 @@ func TestTask_updateDataVolumeRef(t *testing.T) {
 				Name: "dv-0",
 			},
 			ns:              "ns-0",
-			expectedFailure: true,
+			expectedFailure: false,
 			wantErr:         false,
 		},
 		{
@@ -195,7 +195,6 @@ func TestTask_swapVirtualMachinePVCRefs(t *testing.T) {
 					},
 				},
 			},
-			expectedFailures: []string{"ns-0/vm-0"},
 		},
 		{
 			name:       "VMs with PVCs, no mapping, should return all VMs",
@@ -213,7 +212,6 @@ func TestTask_swapVirtualMachinePVCRefs(t *testing.T) {
 					},
 				}),
 			},
-			expectedFailures: []string{"ns-0/vm-0"},
 		},
 		{
 			name:       "VMs with DVs, mapping to new name, should return no failures",

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -307,6 +307,7 @@ func getStatefulSetVolumeName(pvcName, setName string, plan *migapi.MigPlan) str
 			}
 		}
 	}
+	log.V(3).Info("Returning statefulset formatted Name", "formattedName", formattedName)
 	return formattedName
 }
 


### PR DESCRIPTION
The quiesce function assumed that all resources
in a namespace would be quiesced. This is no longer true with the ability to select volumes in the UI.

This changes fixes that so only the resources that are associated with the selected volumes are quiesced.