### PR TITLE
Support VM volume storage migration between different volume and access modes

### DIFF
--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -390,6 +390,8 @@ spec:
                           type: string
                         namespace:
                           type: string
+                        ownerType:
+                          type: string
                         volumeMode:
                           description: PersistentVolumeMode describes how a volume
                             is intended to be consumed, either Block or Filesystem.

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -885,6 +885,20 @@ type PV struct {
 	ProposedCapacity  resource.Quantity     `json:"proposedCapacity,omitempty"`
 }
 
+type OwnerType string
+
+const (
+	VirtualMachine   OwnerType = "VirtualMachine"
+	Deployment       OwnerType = "Deployment"
+	DeploymentConfig OwnerType = "DeploymentConfig"
+	StatefulSet      OwnerType = "StatefulSet"
+	ReplicaSet       OwnerType = "ReplicaSet"
+	DaemonSet        OwnerType = "DaemonSet"
+	Job              OwnerType = "Job"
+	CronJob          OwnerType = "CronJob"
+	Unknown          OwnerType = "Unknown"
+)
+
 // PVC
 type PVC struct {
 	Namespace    string                            `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
@@ -892,6 +906,7 @@ type PVC struct {
 	AccessModes  []kapi.PersistentVolumeAccessMode `json:"accessModes,omitempty" protobuf:"bytes,1,rep,name=accessModes,casttype=PersistentVolumeAccessMode"`
 	VolumeMode   kapi.PersistentVolumeMode         `json:"volumeMode,omitempty"`
 	HasReference bool                              `json:"hasReference,omitempty"`
+	OwnerType    OwnerType                         `json:"ownerType,omitempty"`
 }
 
 // GetTargetName returns name of the target PVC

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -116,6 +116,7 @@ func (t *Task) createDestinationDV(srcClient, destClient compat.Client, pvc miga
 		}
 	}
 	destPVC.Spec.Resources.Requests[corev1.ResourceStorage] = size
+	destPVC.Spec.VolumeMode = pvc.TargetVolumeMode
 	return createBlankDataVolumeFromPVC(destClient, destPVC)
 }
 

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -243,7 +243,7 @@ func (r *ReconcileMigMigration) Reconcile(ctx context.Context, request reconcile
 	// Validate
 	err = r.validate(ctx, migration)
 	if err != nil {
-		log.Info("Validation failed, requeueing")
+		log.V(3).Info("Validation failed, requeueing")
 		sink.Trace(err)
 		return reconcile.Result{Requeue: true}, nil
 	}


### PR DESCRIPTION
This allows the user to live migration VMs from filesystem to block and vice versa. It also allows the user to change the access mode to RWX or RWO depending on their needs.

When creating the target volumes, use a datavolume to create the appropriate PVCs, this allows the user to select the storage profile to pick the correct combination for the selected storage class.

Added ownertType of PVs, this helps the UI display the selection table correctly. Based on the ownerType it can change the appearance of the table.