### PR TITLE
Was looking at the owner name instead of the pod name

### DIFF
--- a/pkg/controller/directvolumemigration/vm.go
+++ b/pkg/controller/directvolumemigration/vm.go
@@ -182,7 +182,7 @@ func getRunningVmVolumeMap(client k8sclient.Client, namespace string) (map[strin
 						}
 					}
 				}
-				if owner.Kind == PodKind && strings.HasPrefix(owner.Name, "hp-") {
+				if owner.Kind == PodKind && strings.HasPrefix(pod.Name, "hp-") {
 					if ownerPod, ok := podNameMap[owner.Name]; ok {
 						if ownerPod.Name == owner.Name {
 							for _, volume := range pod.Spec.Volumes {


### PR DESCRIPTION
This meant instead of checking if the pod had a
particular prefix it was looking at the owner instead and caused the pod to be skipped.