### PR TITLE
Add a verifyVM stage that checks if any running

### DIFF
--- a/pkg/controller/directvolumemigration/descriptions.go
+++ b/pkg/controller/directvolumemigration/descriptions.go
@@ -37,4 +37,5 @@ var phaseDescriptions = map[string]string{
 	RunRsyncOperations:                   "Running Rsync Pods to migrate Persistent Volume data",
 	MigrationFailed:                      "The migration attempt failed, please see errors for more details",
 	Completed:                            "Complete",
+	VerifyVMs:                            "Verifying the running source VMs can be migrated",
 }


### PR DESCRIPTION
VMs have an ephemeral hotplugged disk. This is not allowed when attempting to storage migrate.

Return an error the user can understand solve the
problem.