### PR TITLE
During run of task if the task errors, instead

### DIFF
--- a/pkg/controller/migmigration/dvm_test.go
+++ b/pkg/controller/migmigration/dvm_test.go
@@ -57,6 +57,7 @@ func TestTask_hasDirectVolumeMigrationCompleted(t1 *testing.T) {
 							},
 						},
 					},
+					Errors: []string{"direct volume migration failed. 1 total volumes; 0 successful; 0 running; 1 failed"},
 				},
 			}},
 			wantProgress:       []string{"[pvc-0] ns/foo: Failed"},

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -79,6 +79,7 @@ func (r *ReconcileMigMigration) migrate(ctx context.Context, migration *migapi.M
 			"phaseDescription", task.getPhaseDescription(task.Phase),
 			"error", errorutil.Unwrap(err).Error())
 		sink.Trace(err)
+
 		task.fail(MigrationFailed, []string{err.Error()})
 		return task.Requeue, nil
 	}

--- a/pkg/controller/migmigration/storage.go
+++ b/pkg/controller/migmigration/storage.go
@@ -197,7 +197,7 @@ func (t *Task) handleSourceLabels(client k8sclient.Client, mapping pvcNameMappin
 				labels[directvolumemigration.MigrationSourceFor] = string(t.PlanResources.MigPlan.UID)
 			}
 			pvc.Labels = labels
-			if err := client.Update(context.TODO(), &pvc); err != nil {
+			if err := client.Update(context.TODO(), &pvc); err != nil && !k8serrors.IsConflict(err) && !k8serrors.IsNotFound(err) {
 				failedPVCs = append(failedPVCs, fmt.Sprintf("failed to modify labels on PVC %s/%s", pvc.Namespace, pvc.Name))
 			}
 		}

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
@@ -11,6 +12,7 @@ import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
+	dvmc "github.com/konveyor/mig-controller/pkg/controller/directvolumemigration"
 	"github.com/konveyor/mig-controller/pkg/errorutil"
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/opentracing/opentracing-go"
@@ -1919,6 +1921,9 @@ func (t *Task) waitForDVMToComplete(dvm *migapi.DirectVolumeMigration) error {
 		step.MarkCompleted()
 		if len(reasons) > 0 {
 			t.setDirectVolumeMigrationFailureWarning(dvm)
+			if dvm.Status.HasCriticalCondition(dvmc.Failed) {
+				return fmt.Errorf("DVM failed: %s", strings.Join(reasons, ", "))
+			}
 		}
 		if err := t.next(); err != nil {
 			return liberr.Wrap(err)

--- a/pkg/controller/migmigration/task_test.go
+++ b/pkg/controller/migmigration/task_test.go
@@ -305,6 +305,7 @@ func TestTask_waitForDMVToComplete(t *testing.T) {
 							},
 						},
 					},
+					Errors: []string{"error"},
 				},
 			},
 			initialConditions: []migapi.Condition{},


### PR DESCRIPTION
of warning and continuing, return an error and stop the task. This is so that validations have the ability to stop the task before anything happens.

Don't add PVCs that are created by the plan and don't add temporary PVCs (like scratch space and prime pvcs from CDI).