### PR TITLE
Kubevirt 1.5 and newer GAed live update features

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -1735,7 +1735,7 @@ func (r *ReconcileMigPlan) validateKubeVirtInstalled(ctx context.Context, client
 		kubevirt.Spec.Configuration.DeveloperConfiguration == nil ||
 		!slices.Contains(kubevirt.Spec.Configuration.DeveloperConfiguration.FeatureGates, VolumesUpdateStrategy) ||
 		!slices.Contains(kubevirt.Spec.Configuration.DeveloperConfiguration.FeatureGates, VolumeMigrationConfig) ||
-		!slices.Contains(kubevirt.Spec.Configuration.DeveloperConfiguration.FeatureGates, VMLiveUpdateFeatures) {
+		(major == 1 && minor < 5 && !slices.Contains(kubevirt.Spec.Configuration.DeveloperConfiguration.FeatureGates, VMLiveUpdateFeatures)) {
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     KubeVirtStorageLiveMigrationNotEnabled,
 			Status:   True,


### PR DESCRIPTION
In the plan validation we check if the kubevirt version supports storage live migration. In kubevirt 1.5 one of the feature gates was made GA, and is no longer set. This skips the check for that feature gate if kubevirt is 1.5 or newer.