### PR TITLE
Mark rsync failures as fatal errors during migration

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -454,13 +454,13 @@ func (t *Task) Run(ctx context.Context) error {
 	case RunRsyncOperations:
 		allCompleted, anyFailed, failureReasons, err := t.runRsyncOperations()
 		if err != nil {
-			return liberr.Wrap(err)
+			return liberr.Wrap(FatalPlanError, err.Error())
 		}
 		t.Requeue = PollReQ
 		if allCompleted {
 			t.Requeue = NoReQ
 			if anyFailed {
-				t.fail(MigrationFailed, Advisory, failureReasons)
+				t.fail(MigrationFailed, Critical, failureReasons)
 				return nil
 			}
 			if err = t.next(); err != nil {


### PR DESCRIPTION
rsync failures were not marked fatal, and not fail the migration process. Mark rsync failures as fatal which will properly indicate that the migration failed