### PR TITLE
Properly count quiesced VM pods

### DIFF
--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -1344,13 +1344,17 @@ func (t *Task) ensureQuiescedPodsTerminated(client compat.Client, namespaces []s
 			return false, liberr.Wrap(err)
 		}
 		for _, pod := range list.Items {
+			skip := false
 			for _, v := range pod.Spec.Volumes {
 				if v.PersistentVolumeClaim != nil && selectedPVCs[ns].Has(v.PersistentVolumeClaim.ClaimName) {
 					t.Log.Info("Found pvc that matches, pod still running", "pvc", v.PersistentVolumeClaim.ClaimName)
 				} else if v.PersistentVolumeClaim != nil {
 					t.Log.Info("No pvc that matches", "pvc", v.PersistentVolumeClaim.ClaimName)
-					continue
+					skip = true
 				}
+			}
+			if skip {
+				continue
 			}
 			if pod.Annotations == nil {
 				pod.Annotations = make(map[string]string)


### PR DESCRIPTION
If multiple VMs exist in a namespace and there are multiple plans for those VMs. Running a cutover for one plan would wait for all the VMs to be quiesced, which would not happen. This fixes the check that determines which VMs should be quiesced and which ones we are waiting on.