### PR TITLE
Mark new PVs in the plan as skip by default instead of copy

### DIFF
--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -565,12 +565,12 @@ func (r *ReconcileMigPlan) getDefaultSelection(pv core.PersistentVolume,
 	}
 	actions := r.getSupportedActions(pv, claim)
 	selectedAction := ""
-	// if there's only one action, make that the default, otherwise select "copy" (if available)
+	// if there's only one action, make that the default, otherwise select "skip" (if available)
 	if len(actions) == 1 {
 		selectedAction = actions[0]
 	} else {
 		for _, a := range actions {
-			if a == migapi.PvCopyAction {
+			if a == migapi.PvSkipAction {
 				selectedAction = a
 				break
 			}


### PR DESCRIPTION
When new PVs appear in the namespace any plans will automatically add them to the plan. But if the action is marked as copy it will create conflicts between plans

This defaults the action to skip instead so no conflicts happen.