### PR TITLE
Revert "Mark new PVs in the plan as skip by default instead of copy"

### DIFF
--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -565,12 +565,12 @@ func (r *ReconcileMigPlan) getDefaultSelection(pv core.PersistentVolume,
 	}
 	actions := r.getSupportedActions(pv, claim)
 	selectedAction := ""
-	// if there's only one action, make that the default, otherwise select "skip" (if available)
+	// if there's only one action, make that the default, otherwise select "copy" (if available)
 	if len(actions) == 1 {
 		selectedAction = actions[0]
 	} else {
 		for _, a := range actions {
-			if a == migapi.PvSkipAction {
+			if a == migapi.PvCopyAction {
 				selectedAction = a
 				break
 			}


### PR DESCRIPTION
Reverts migtools/mig-controller#1412