### PR TITLE
Konflux: openshift-preflight: failed: HasLicense

### DIFF
--- a/Dockerfile.rhmtc
+++ b/Dockerfile.rhmtc
@@ -17,5 +17,6 @@ FROM registry.redhat.io/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/crane/crane .
+COPY LICENSE /licenses/
 USER 65534:65534
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
"suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory."

https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction

> Container images must contain a “licenses” directory. Use this
> directory to add files containing software terms and conditions for your
> product and any open source software included in the image.
>
> Test name: HasLicense