### PR TITLE
Remove selected node annotation from PVC/DV so the newly created blank one does not get it

### DIFF
--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -74,7 +74,7 @@ func (t *Task) createDestinationDV(srcClient, destClient compat.Client, pvc miga
 
 	// Remove any cdi related annotations from the PVC
 	for k := range destPVC.Annotations {
-		if strings.HasPrefix(k, "cdi.kubevirt.io") {
+		if strings.HasPrefix(k, "cdi.kubevirt.io") || strings.HasPrefix(k, "volume.kubernetes.io/selected-node") {
 			delete(destPVC.Annotations, k)
 		}
 	}


### PR DESCRIPTION
If left it will bind the PV to the same node as the original and the migration will fail.

Fixes: https://issues.redhat.com/browse/MIG-1750