### PR TITLE
Upgrade Go to 1.26 to fix 3 CVEs [release-1.8]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/mig-controller
 
-go 1.25.0
+go 1.26
 
 require (
 	cloud.google.com/go/storage v1.56.0


### PR DESCRIPTION
## Summary
- Upgrades Go from 1.25.0 to 1.26 to fix 3 CVEs

## CVEs Fixed
- **MIG-2019**: CVE-2026-48050 - Arc: Information disclosure and DoS via unauthenticated debug endpoints
- **MIG-1987**: CVE-2026-56858 - Go html/template: Cross-Site Scripting via pathological input  
- **MIG-1980**: CVE-2026-41178 - OpenTelemetry-Go: DoS via oversized baggage headers

## Changes
- Updated `go.mod`: `go 1.25.0` → `go 1.26`

## Jira Tickets
- https://redhat.atlassian.net/browse/MIG-2019
- https://redhat.atlassian.net/browse/MIG-1987
- https://redhat.atlassian.net/browse/MIG-1980

🤖 Generated with [Claude Code](https://claude.com/claude-code)