### PR TITLE
Upgrade Go to 1.26.6 to fix CVE-2026-56858

### DIFF
--- a/.github/workflows/pr-make.yml
+++ b/.github/workflows/pr-make.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.25
+          go-version: 1.26
       - name: Setup dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y libgpgme-dev libdevmapper-dev btrfs-progs libbtrfs-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM golang:1.26.6-alpine AS builder
+FROM quay.io/konveyor/builder:ubi8-v1.26 AS builder
 
-# Install build dependencies
-RUN apk add --no-cache gcc musl-dev git
-
-# Set up workspace
-ENV APP_ROOT=/opt/app-root
+# Copy in the go src
 WORKDIR $APP_ROOT/src/github.com/konveyor/mig-controller
 COPY pkg/    pkg/
 COPY cmd/    cmd/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM quay.io/konveyor/builder:latest AS builder
+FROM golang:1.26.6-alpine AS builder
 
-# Copy in the go src
+# Install build dependencies
+RUN apk add --no-cache gcc musl-dev git
+
+# Set up workspace
+ENV APP_ROOT=/opt/app-root
 WORKDIR $APP_ROOT/src/github.com/konveyor/mig-controller
 COPY pkg/    pkg/
 COPY cmd/    cmd/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/mig-controller
 
-go 1.25.0
+go 1.26
 
 require (
 	cloud.google.com/go/storage v1.56.0


### PR DESCRIPTION
## Summary
- Upgrades Go from 1.25.0 to 1.26.6 to fix html/template XSS vulnerability
- Updates Dockerfile to use explicit golang:1.26.6-alpine instead of quay.io/konveyor/builder:latest

## CVE Fixed
- **MIG-1987**: CVE-2026-56858 - Go html/template: Cross-Site Scripting via pathological input
  - Affected: Go 1.26.0 to 1.26.5
  - Fixed in: Go 1.26.6+

## Changes
- Updated `Dockerfile`: `FROM quay.io/konveyor/builder:latest` → `FROM golang:1.26.6-alpine`
- Added build dependencies for CGO builds (gcc, musl-dev, git)
- Updated `go.mod`: `go 1.25.0` → `go 1.26`

## Jira Ticket
- https://redhat.atlassian.net/browse/MIG-1987

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project build and pull request test environments to use Go 1.26.
  * Aligned the declared Go version with the updated build tooling.
  * Pinned the build environment to a specific compatible image version.
  * No user-facing product behavior or public functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->